### PR TITLE
Bugfix/20612 can iface support

### DIFF
--- a/confed/interfaces.schema.json
+++ b/confed/interfaces.schema.json
@@ -276,7 +276,7 @@
             "required": ["bitrate"]
             }
           },
-          "defaultProperties": ["auto", "mode", "method", "options"],
+          "defaultProperties": ["allow-hotplug", "mode", "method", "options"],
           "required": ["name", "mode", "method"]
         }
       ]

--- a/confed/interfaces.schema.json
+++ b/confed/interfaces.schema.json
@@ -77,6 +77,13 @@
         {
           "type": "object",
           "properties": {
+            "mode": {
+              "type": "string",
+              "options": {
+                    "hidden": true
+                  },
+              "enum": ["inet"]
+            },
             "method": {
               "type": "string",
               "options": {
@@ -91,7 +98,8 @@
               }
             }
           },
-          "required": ["method"]
+          "defaultProperties": ["mode"],
+          "required": ["method", "mode"]
         }
       ]
     },
@@ -102,6 +110,13 @@
         {
           "type": "object",
           "properties": {
+            "mode": {
+              "type": "string",
+              "options": {
+                    "hidden": true
+                  },
+              "enum": ["inet"]
+            },
             "method": {
               "type": "string",
               "options": {
@@ -172,8 +187,8 @@
               "defaultProperties": ["address", "netmask", "gateway", "mtu"]
             }
           },
-          "defaultProperties": ["auto", "method", "options"],
-          "required": ["name", "method"]
+          "defaultProperties": ["auto", "mode", "method", "options"],
+          "required": ["name", "mode", "method"]
         }
       ]
     },
@@ -184,6 +199,13 @@
         {
           "type": "object",
           "properties": {
+            "mode": {
+              "type": "string",
+              "options": {
+                    "hidden": true
+                  },
+              "enum": ["inet"]
+            },
             "method": {
               "type": "string",
               "options": {
@@ -215,8 +237,47 @@
               "defaultProperties": "hostname"
             }
           },
-          "defaultProperties": ["auto", "method", "options"],
-          "required": ["name", "method"]
+          "defaultProperties": ["auto", "mode", "method", "options"],
+          "required": ["name", "mode", "method"]
+        }
+      ]
+    },
+    "method_can": {
+      "title": "CAN",
+      "allOf": [
+        { "$ref": "#/definitions/iface_common" },
+        {
+          "type": "object",
+          "properties": {
+            "mode": {
+              "type": "string",
+              "options": {
+                    "hidden": true
+                  },
+              "enum": ["can"]
+            },
+            "method": {
+              "type": "string",
+              "options": {
+                "hidden": true
+              },
+              "enum": ["static"]
+            },
+            "options": {
+              "type": "object",
+              "title": "Options",
+              "properties": {
+                "bitrate": {
+                  "type": "string",
+                  "title": "Bitrate",
+                  "propertyOrder": 11
+                }
+              },
+            "required": ["bitrate"]
+            }
+          },
+          "defaultProperties": ["auto", "mode", "method", "options"],
+          "required": ["name", "mode", "method"]
         }
       ]
     },
@@ -227,6 +288,13 @@
         {
           "type": "object",
           "properties": {
+            "mode": {
+              "type": "string",
+              "options": {
+                    "hidden": true
+                  },
+              "enum": ["inet"]
+            },
             "method": {
               "type": "string",
               "options": {
@@ -258,8 +326,8 @@
               "defaultProperties": ["provider"]
             }
           },
-          "defaultProperties": ["auto", "method", "options"],
-          "required": ["name", "method"]
+          "defaultProperties": ["auto", "mode", "method", "options"],
+          "required": ["name", "mode", "method"]
         }
       ]
     },
@@ -270,6 +338,13 @@
         {
           "type": "object",
           "properties": {
+            "mode": {
+              "type": "string",
+              "options": {
+                    "hidden": true
+                  },
+              "enum": ["inet"]
+            },
             "method": {
               "type": "string",
               "options": {
@@ -296,8 +371,8 @@
               "defaultProperties": ["mtu"]
             }
           },
-          "defaultProperties": ["auto", "method"],
-          "required": ["name", "method"]
+          "defaultProperties": ["auto", "mode", "method"],
+          "required": ["name", "mode", "method"]
         }
       ]
     }
@@ -313,6 +388,7 @@
           { "$ref": "#/definitions/method_static" },
           { "$ref": "#/definitions/method_dhcp" },
           { "$ref": "#/definitions/method_ppp" },
+          { "$ref": "#/definitions/method_can" },
           { "$ref": "#/definitions/method_manual" }
         ]
       },

--- a/confed/interfaces.schema.json
+++ b/confed/interfaces.schema.json
@@ -98,8 +98,8 @@
               }
             }
           },
-          "defaultProperties": ["mode"],
-          "required": ["method", "mode"]
+          "defaultProperties": ["name", "method", "mode"],
+          "required": ["name", "method", "mode"]
         }
       ]
     },
@@ -187,7 +187,7 @@
               "defaultProperties": ["address", "netmask", "gateway", "mtu"]
             }
           },
-          "defaultProperties": ["auto", "mode", "method", "options"],
+          "defaultProperties": ["name", "auto", "mode", "method", "options"],
           "required": ["name", "mode", "method"]
         }
       ]
@@ -237,7 +237,7 @@
               "defaultProperties": "hostname"
             }
           },
-          "defaultProperties": ["auto", "mode", "method", "options"],
+          "defaultProperties": ["name", "auto", "mode", "method", "options"],
           "required": ["name", "mode", "method"]
         }
       ]
@@ -276,7 +276,7 @@
             "required": ["bitrate"]
             }
           },
-          "defaultProperties": ["allow-hotplug", "mode", "method", "options"],
+          "defaultProperties": ["name", "allow-hotplug", "mode", "method", "options"],
           "required": ["name", "mode", "method"]
         }
       ]
@@ -326,7 +326,7 @@
               "defaultProperties": ["provider"]
             }
           },
-          "defaultProperties": ["auto", "mode", "method", "options"],
+          "defaultProperties": ["name", "auto", "mode", "method", "options"],
           "required": ["name", "mode", "method"]
         }
       ]
@@ -371,7 +371,7 @@
               "defaultProperties": ["mtu"]
             }
           },
-          "defaultProperties": ["auto", "mode", "method"],
+          "defaultProperties": ["name", "auto", "mode", "method"],
           "required": ["name", "mode", "method"]
         }
       ]

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-confed (1.2.3) stable; urgency=medium
+
+  * added support of CAN-interface
+
+ -- Vladimir Romanov <v.romanov@wirenboard.ru>  Thr, 10 Dec 2020 17:28:13 +0300
+
 wb-mqtt-confed (1.2.2) stable; urgency=medium
 
   * require mosquitto to start service
@@ -19,7 +25,7 @@ wb-mqtt-confed (1.2) stable; urgency=medium
 
 wb-mqtt-confed (1.1) stable; urgency=medium
 
-  * Add /etc/ntp.conf schema and converter 
+  * Add /etc/ntp.conf schema and converter
 
  -- Nikita Maslov <n.maslov@contactless.ru>  Wed, 13 Jul 2016 14:53:36 +0300
 
@@ -47,5 +53,3 @@ wb-mqtt-confed (1.0) wheezy; urgency=low
   * Initial package version
 
  -- Ivan Shvedunov <ivan4th@gmail.com>  Mon, 12 Sep 2015 06:49:00 +0300
-
-

--- a/networkparser
+++ b/networkparser
@@ -287,7 +287,7 @@ class NetworkParser(object):
             if iface.get("allow-hotplug"):
                 output += "allow-hotplug %s\n" % name
 
-            output += "iface %s inet %s\n" % (name, iface.get("method", "manual"))
+            output += "iface %s %s %s\n" % (name, iface.get("mode", "inet"), iface.get("method", "manual"))
             # options
             options = iface.get("options", {})
             if not isinstance(options, dict):
@@ -341,6 +341,8 @@ class NetworkParser(object):
             if idefinition[0] == "allow-hotplug":
                 iface["allow-hotplug"] = True
             elif idefinition[0] == "iface":
+                mode = idefinition[2]
+                iface["mode"] = mode
                 method = idefinition[3]
                 iface["method"] = method
             # check for options

--- a/networkparser
+++ b/networkparser
@@ -180,7 +180,7 @@ class NetworkParser(object):
                        "pointtopoint|metric|hwaddress|mtu|hostname|"
                        "leasehours|leasetime|vendor|client|bootfile|server"
                        "|mode|endpoint|dstaddr|local|ttl|provider|unit"
-                       "|options|frame|netnum|media|wpa-[\w-]*")
+                       "|options|frame|bitrate|netnum|media|wpa-[\w-]*")
     _eol = Literal("\n").suppress()
     option = Forward()
     option << Group(space
@@ -194,7 +194,7 @@ class NetworkParser(object):
                              + interface
                              + Optional(
                                  space
-                                 + Regex("inet")
+                                 + Regex("inet|can")
                                  + method
                                  + Group(ZeroOrMore(option))))
 


### PR DESCRIPTION
Проблема - конфед не мог распарсить настройки can вида: `iface can0 can static` => веб-интерфейс кидал ошибку, если руками вписать такое в конфиг.
Теперь - может. В схему и python-парсер за ней добавился параметр mode (inet/can)

Теперь кан можно настраивать без терминала:
1. Прописать интерфейс тут
2. Выставить can в хвконфе

Из-за allow-hotplug интерфейс будет сам подниматься при включении/отключении can в хвконфе/при старте системы.
Проверено на пакете из дженкинса