### PR TITLE
Config translations support

### DIFF
--- a/confed/sample-translations.schema.json
+++ b/confed/sample-translations.schema.json
@@ -1,0 +1,48 @@
+{
+  "type": "object",
+  "title": "Example Config",
+  "description": "Just an example",
+  "properties": {
+    "device_type": {
+      "type": "string",
+      "enum": {
+        "directories": ["/sample_devtypes"],
+        "pointer": "/device_type",
+        "pattern": "^.*\\.conf$"
+      },
+      "title": "Device type",
+      "description": "Modbus device template to use"
+    },
+    "name": {
+      "type": "string",
+      "title": "Device name",
+      "description": "Device name to be displayed in UI"
+    },
+    "id": {
+      "type": "string",
+      "title": "Device ID",
+      "description": "Device identifier to be used as a part of MQTT topic"
+    },
+    "enabled": {
+      "type": "boolean",
+      "title": "Enabled",
+      "description": "Check to enable device polling"
+    },
+    "slave_id": {
+      "type": "integer",
+      "title": "Slave ID",
+      "description": "Modbus Slave ID",
+      "minimum": 0
+    }
+  },
+  "required": ["device_type", "slave_id"],
+  "configFile": {
+    "path": "/sample.json"
+  },
+  "translations": {
+    "ru": {
+      "Example Config": "Пример конфига",
+      "Just an example": "Пример описания"
+    }
+  }
+}

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-confed (1.4.0) stable; urgency=medium
+
+  * Translations of title and description of config files are added to Editor.List RPC response
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.ru>  Tue, 07 Sep 2021 08:59:11 +0500
+
 wb-mqtt-confed (1.3.0) stable; urgency=medium
 
   * use go 1.15 compiler


### PR DESCRIPTION
Rebase of https://github.com/wirenboard/wb-mqtt-confed/pull/16
Title and descriprion translations are added to Editor.List RPC response. Translations should be defined in "translations" property of a schema.