### PR TITLE
"hide" in "configFile" section of a config's schema

### DIFF
--- a/confed/editor.go
+++ b/confed/editor.go
@@ -175,7 +175,9 @@ func (editor *Editor) List(args *struct{}, reply *[]*JSONSchemaProps) (err error
 
 	*reply = make([]*JSONSchemaProps, 0, len(editor.schemasBySchemaPath))
 	for _, schema := range editor.schemasBySchemaPath {
-		*reply = append(*reply, schema.Properties())
+		if !schema.HideFromList() {
+			*reply = append(*reply, schema.Properties())
+		}
 	}
 	sort.Sort(ByConfigThenSchemaPath(*reply))
 	return

--- a/confed/schema.go
+++ b/confed/schema.go
@@ -22,6 +22,7 @@ type JSONSchemaProps struct {
 	service                 string
 	restartDelayMS          int
 	shouldValidate          bool
+	hideFromList            bool
 	TitleTranslations       map[string]string `json:"titleTranslations,omitempty"`
 	DescriptionTranslations map[string]string `json:"descriptionTranslations,omitempty"`
 }
@@ -116,6 +117,11 @@ func NewJSONSchemaWithRoot(schemaPath, root string) (s *JSONSchema, err error) {
 		shouldValidate = true
 	}
 
+	hideFromList, ok := configFile["hide"].(bool)
+	if !ok {
+		hideFromList = false
+	}
+
 	service, _ := configFile["service"].(string)
 	restartDelayMS, _ := configFile["restartDelayMS"].(float64)
 
@@ -127,7 +133,7 @@ func NewJSONSchemaWithRoot(schemaPath, root string) (s *JSONSchema, err error) {
 		return
 	}
 
-	// A shema could contain "translations" property
+	// A schema could contain "translations" property
 	// Expected structure of the property:
 	// "translations": {
 	//     "lang": {
@@ -164,6 +170,7 @@ func NewJSONSchemaWithRoot(schemaPath, root string) (s *JSONSchema, err error) {
 			service:                 service,
 			restartDelayMS:          int(restartDelayMS),
 			shouldValidate:          shouldValidate,
+			hideFromList:            hideFromList,
 			TitleTranslations:       titleTranslations,
 			DescriptionTranslations: descriptionTranslations,
 		},
@@ -256,6 +263,10 @@ func (s *JSONSchema) RestartDelayMS() int {
 
 func (s *JSONSchema) ShouldValidate() bool {
 	return s.props.shouldValidate
+}
+
+func (s *JSONSchema) HideFromList() bool {
+	return s.props.hideFromList
 }
 
 func (s *JSONSchema) Properties() *JSONSchemaProps {

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+wb-mqtt-confed (1.8.0) stable; urgency=medium
+
+  * Support for option "hide" is added to "configFile" section of a config's schema. 
+    Setting it to true removes the config from response to "List" RPC request.
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.ru>  Tue, 14 Dec 2021 11:46:03 +0500
+
 wb-mqtt-confed (1.7.0) stable; urgency=medium
 
   * Support for loading schemas from /var/lib/wb-mqtt-confed/schemas


### PR DESCRIPTION
Setting it to true removes the config from response to "List" RPC request.