### PR TITLE
add mosquitto socket support

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+wb-mqtt-confed (1.10.0) stable; urgency=medium
+
+  * add mosquitto UNIX socket connection support
+    This is required for Bullseye migration, where mosquitto 2.0 is used.
+
+ -- Nikita Maslov <nikita.maslov@wirenboard.ru>  Tue, 21 Jun 2022 14:44:23 +0300
+
 wb-mqtt-confed (1.9.0) stable; urgency=medium
 
   * using of wbgong plugin system


### PR DESCRIPTION
Поддержка соединения с mosquitto через UNIX socket (`/var/run/mosquitto/mosquitto.sock`) требуется для переезда на bullseye, где используется mosquitto 2.0, и локальные соединения через сокет заменяют хак с `allow_anonymous_localhost`.

Поддержка такого соединения уже добавлена в кучу наших сервисов и в libwbmqtt1. В confed она ждала миграции на wbgong.