### PR TITLE
Fix display of "Auto" checkbox for network interface

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-confed (1.9.2) stable; urgency=medium
+
+  * Fix display of "Auto" checkbox for network interface
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.ru>  Fri, 12 Aug 2022 17:43:25 +0500
+
 wb-mqtt-confed (1.9.1) stable; urgency=medium
 
   * NTP and network interfaces config editors UI update.

--- a/networkparser
+++ b/networkparser
@@ -338,6 +338,8 @@ class NetworkParser(object):
             # auto?
             if idefinition[0] == "auto":
                 iface["auto"] = True
+            else
+                iface["auto"] = False
             if idefinition[0] == "allow-hotplug":
                 iface["allow-hotplug"] = True
             elif idefinition[0] == "iface":


### PR DESCRIPTION
Раньше чекбокс `Включать автоматически`рисовался только, если он был с галочкой. Без галочки не рисовался, надо было лезть в параметры. Теперь рисуется.
![изображение](https://user-images.githubusercontent.com/86825564/184358314-a0d94804-6673-4b73-99c7-9b0813dcef16.png)
