### PR TITLE
fix networkparser logic error while parsing auto stanza

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-confed (1.11.3) stable; urgency=medium
+
+  * fix networkparser logic error while parsing 'auto' stanza
+
+ -- Nikita Maslov <nikita.maslov@wirenboard.ru>  Mon, 07 Nov 2022 14:44:50 +0600
+
 wb-mqtt-confed (1.11.2) stable; urgency=medium
 
   * fix networkparser syntax error

--- a/networkparser
+++ b/networkparser
@@ -331,14 +331,12 @@ class NetworkParser(object):
             if name in interfaces:
                 iface = interfaces[name]
             else:
-                iface = dict(name=name)
+                iface = dict(name=name, auto=False)
                 interfaces[name] = iface
                 r.append(iface)
             # auto?
             if idefinition[0] == "auto":
                 iface["auto"] = True
-            else:
-                iface["auto"] = False
             if idefinition[0] == "allow-hotplug":
                 iface["allow-hotplug"] = True
             elif idefinition[0] == "iface":


### PR DESCRIPTION
Сломалось в #31 (проглядел на ревью не только синтаксическую ошибку, но и логическую).

После #31 `auto` ставилось в `True` только у интерфейсов, у которых `auto` прописано самой последней строфой, касающейся этого интерфейса. Теперь должно стать лучше.