### PR TITLE
rebuild with properly working wbgo

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-confed (1.11.4+b1) stable; urgency=medium
+
+  * rebuild with properly working wbgo
+
+ -- Nikita Maslov <nikita.maslov@wirenboard.ru>  Mon, 07 Nov 2022 19:19:47 +0600
+
 wb-mqtt-confed (1.11.4) stable; urgency=medium
 
   * update wbgo in go.mod


### PR DESCRIPTION
Персборка с https://github.com/wirenboard/wbgo-private/pull/36, исходники не меняются. Версию поднял, потому что в репозиторий уже уехала оригинальная (сломанный пакет)