### PR TITLE
Fix /etc/network/interfaces editing

### DIFF
--- a/confed/interfaces.schema.json
+++ b/confed/interfaces.schema.json
@@ -467,8 +467,7 @@
                     "wb": {
                         "disable_panel": true
                     }
-            },
-                "_format": "wb-multiple"
+                }
             },
             "_format": "tabs",
             "options": {

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-confed (1.11.5) stable; urgency=medium
+
+  * Fix /etc/network/interfaces editing
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.ru>  Mon, 07 Nov 2022 21:58:50 +0500
+
 wb-mqtt-confed (1.11.4+b1) stable; urgency=medium
 
   * rebuild with properly working wbgo


### PR DESCRIPTION
`wb-multiple` предназначен для редактирования схемы `oneOf`. Текущую выбраннуюFix /etc/network/interfaces editingхему он определяет по первому параметру из `required`. Я делал такую оптимизацию для `wb-mqtt-serial`, чтобы не тратить много времени, т.к. там каждая подсхема идентифицируется отдельным параметром с типом устройства.
При редактировании `/etc/network/interfaces` есть параметр `method`, но он не уникальный для `can` и `static`, к тому же в подсхемах этот параметр не стоит первым. В результате при отображении выбирается не та подсхема. Например, для wi-fi можкт быть выбран loopback.
Вернул на стандартный редактор, который проводит полную валидацию, чтобы выбрать подсхему 