### PR TITLE
Fix metric format for default gateway

### DIFF
--- a/confed/interfaces.schema.json
+++ b/confed/interfaces.schema.json
@@ -161,9 +161,8 @@
                                     "propertyOrder": 14
                                 },
                                 "metric": {
-                                    "type": "string",
+                                    "type": "integer",
                                     "title": "Routing metric for default gateway",
-                                    "format": "ipv4",
                                     "propertyOrder": 15
                                 },
                                 "hwaddress": {

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-confed (1.11.6) stable; urgency=medium
+
+  * Fix metric format for default gateway
+
+ -- Roman Kochkin <roman.kochkin@wirenboard.ru>  Tue, 22 Nov 2022 11:59:07 +0300
+
 wb-mqtt-confed (1.11.5) stable; urgency=medium
 
   * Fix /etc/network/interfaces editing

--- a/sample-root/etc/wb-mqtt-confed/schemas/interfaces.schema.json
+++ b/sample-root/etc/wb-mqtt-confed/schemas/interfaces.schema.json
@@ -131,7 +131,6 @@
                 "metric": {
                   "type": "integer",
                   "title": "Routing metric for default gateway",
-                  "format": "ipv4",
                   "propertyOrder": 15
                 },
                 "hwaddress": {


### PR DESCRIPTION
Для [задачи](https://wirenboard.bitrix24.ru/workgroups/group/218/tasks/task/view/54198/) поправил неверный формат в схеме для метрики для default gateway
