### PR TITLE
Fix parsing of /etc/network/interfaces

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-confed (1.11.7) stable; urgency=medium
+
+  * Fix parsing of /etc/network/interfaces without new line at the end of a file
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.com>  Tue, 20 Dec 2022 12:04:49 +0500
+
 wb-mqtt-confed (1.11.6) stable; urgency=medium
 
   * Fix metric format for default gateway

--- a/networkparser
+++ b/networkparser
@@ -208,19 +208,25 @@ class NetworkParser(object):
         self.filename = None
         self.content = None
         if content:
-            self.content = content
+            self._set_content(content)
         elif infile is not None:
             self.filename = infile
             self._read()
         if self.content is not None:
             self.interfaces = self.get_interfaces()
 
+    def _set_content(self, content):
+        if not content.endswith("\n"):
+            self.content = content + "\n"
+        else:
+            self.content = content
+
     def _read(self):
         """
         Reread the contents from the disk
         """
         with codecs.open(self.filename, "r", encoding="utf-8") as f:
-            self.content = f.read()
+            self._set_content(f.read())
 
     def get(self):
         """


### PR DESCRIPTION
Fix parsing of /etc/network/interfaces without new line at the end of a file