### PR TITLE
Reload-or-restart service list

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@ vendor
 
 debian/files
 debian/wb-mqtt-confed*
+debian/debhelper-build-stamp

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,1 +1,1 @@
-buildDebGolangWbgo()
+buildDebGolangWbgo defaultTargets: 'bullseye-armhf'

--- a/confed/editor.go
+++ b/confed/editor.go
@@ -301,8 +301,10 @@ func (editor *Editor) Save(args *EditorSaveArgs, reply *EditorPathResponse) erro
 	}
 
 	reply.Path = args.Path
-	if schema.Service() != "" {
-		editor.RestartCh <- RestartRequest{schema.Service(), schema.RestartDelayMS()}
+	if schema.Service() != nil {
+		for _, service := range schema.Service() {
+			editor.RestartCh <- RestartRequest{service, schema.RestartDelayMS()}
+		}
 	}
 	return nil
 }

--- a/confed/editor.go
+++ b/confed/editor.go
@@ -301,7 +301,7 @@ func (editor *Editor) Save(args *EditorSaveArgs, reply *EditorPathResponse) erro
 	}
 
 	if schema.RestartDelayMS() > 0 {
-		delay = schema.RestartDelayMS()
+		var delay int = schema.RestartDelayMS()
 		wbgong.Debug.Printf("Delay %d ms before restarting services", delay)
 		time.Sleep(time.Duration(delay) * time.Millisecond)
 	} else {

--- a/confed/editor.go
+++ b/confed/editor.go
@@ -301,8 +301,8 @@ func (editor *Editor) Save(args *EditorSaveArgs, reply *EditorPathResponse) erro
 	}
 
 	reply.Path = args.Path
-	if schema.Service() != nil {
-		for _, service := range schema.Service() {
+	if schema.Services() != nil {
+		for _, service := range schema.Services() {
 			editor.RestartCh <- RestartRequest{service, schema.RestartDelayMS()}
 		}
 	}

--- a/confed/editor.go
+++ b/confed/editor.go
@@ -41,7 +41,6 @@ func fixFormatProps(v interface{}) interface{} {
 
 type RestartRequest struct {
 	Name    string
-	DelayMS int
 }
 
 type Editor struct {
@@ -300,7 +299,7 @@ func (editor *Editor) Save(args *EditorSaveArgs, reply *EditorPathResponse) erro
 		return writeError
 	}
 
-	if err = runCommand(false, nil, "sync", schema.PhysicalConfigPath()); err != nil {
+	if _, err = runCommand(false, nil, "sync", schema.PhysicalConfigPath()); err != nil {
 		wbgong.Error.Printf("error sync file %s: %s", schema.PhysicalConfigPath(), err)
 	}
 

--- a/confed/editor.go
+++ b/confed/editor.go
@@ -300,10 +300,14 @@ func (editor *Editor) Save(args *EditorSaveArgs, reply *EditorPathResponse) erro
 		return writeError
 	}
 
+	if err = runCommand(false, nil, "sync", schema.PhysicalConfigPath()); err != nil {
+		wbgong.Error.Printf("error sync file %s: %s", schema.PhysicalConfigPath(), err)
+	}
+
 	reply.Path = args.Path
 	if schema.Services() != nil {
 		for _, service := range schema.Services() {
-			editor.RestartCh <- RestartRequest{service, schema.RestartDelayMS()}
+			editor.RestartCh <- RestartRequest{service}
 		}
 	}
 	return nil

--- a/confed/editor_test.go
+++ b/confed/editor_test.go
@@ -399,8 +399,10 @@ func (s *EditorSuite) TestRestart() {
 	}, objx.Map{
 		"path": "/etc/network/interfaces",
 	})
-	restart := <-s.editor.RestartCh
-	s.Equal(RestartRequest{"networking"}, restart)
+	restart := <-s.editor.RequestCh
+	s.Equal(Request{Sleep,map[string]string{"delay":"4000"}}, restart)
+	restart = <-s.editor.RequestCh
+	s.Equal(Request{Restart,map[string]string{"service":"networking"}}, restart)
 }
 
 func (s *EditorSuite) TestMultipleSchemasPerConfig() {

--- a/confed/editor_test.go
+++ b/confed/editor_test.go
@@ -400,7 +400,7 @@ func (s *EditorSuite) TestRestart() {
 		"path": "/etc/network/interfaces",
 	})
 	restart := <-s.editor.RestartCh
-	s.Equal(RestartRequest{"networking", 4000}, restart)
+	s.Equal(RestartRequest{"networking"}, restart)
 }
 
 func (s *EditorSuite) TestMultipleSchemasPerConfig() {

--- a/confed/restarter.go
+++ b/confed/restarter.go
@@ -2,7 +2,6 @@ package confed
 
 import (
 	"github.com/wirenboard/wbgong"
-	"time"
 )
 
 const (
@@ -18,11 +17,7 @@ func RunRestarter(ch chan RestartRequest) {
 	go func() {
 		for {
 			req := <-ch
-			wbgong.Debug.Printf("Restarting service %s (delay %d ms)",
-				req.Name, req.DelayMS)
-			if req.DelayMS > 0 {
-				time.Sleep(time.Duration(req.DelayMS) * time.Millisecond)
-			}
+			wbgong.Debug.Printf("Restarting service %s", req.Name)
 			if err := restartService(req.Name); err != nil {
 				wbgong.Error.Printf("Error restarting %s: %s", req.Name, err)
 			}

--- a/confed/restarter.go
+++ b/confed/restarter.go
@@ -10,7 +10,7 @@ const (
 )
 
 func restartService(name string) (err error) {
-	_, err = runCommand(false, nil, SERVICE_CMD, name, "restart")
+	_, err = runCommand(false, nil, SERVICE_CMD, name, "restart-or-reload")
 	return
 }
 

--- a/confed/restarter.go
+++ b/confed/restarter.go
@@ -1,7 +1,10 @@
 package confed
 
 import (
+	"time"
+
 	"github.com/wirenboard/wbgong"
+	"strconv"
 )
 
 const (
@@ -13,13 +16,29 @@ func restartService(name string) (err error) {
 	return
 }
 
-func RunRestarter(ch chan RestartRequest) {
+func RunRequestHandler(ch chan Request) {
 	go func() {
 		for {
 			req := <-ch
-			wbgong.Debug.Printf("Restarting service %s", req.Name)
-			if err := restartService(req.Name); err != nil {
-				wbgong.Error.Printf("Error restarting %s: %s", req.Name, err)
+			switch req.requestType {
+			case Sleep:
+				delay, _ := strconv.Atoi(req.properties["delay"])
+				wbgong.Debug.Printf("Delay %d ms before restarting services", delay)
+				time.Sleep(time.Duration(delay) * time.Millisecond)
+			case Sync:
+				var path string = req.properties["path"]
+				wbgong.Debug.Printf("File sync %s", path)
+				if _, err := runCommand(false, nil, "sync", path); err != nil {
+					wbgong.Error.Printf("Error sync file %s: %s", path, err)
+				}
+			case Restart:
+				var service string = req.properties["service"]
+				wbgong.Debug.Printf("Restarting service %s", service)
+				if err := restartService(service); err != nil {
+					wbgong.Error.Printf("Error restarting %s: %s", service, err)
+				}
+			default:
+				wbgong.Debug.Printf("Unknown request type %d", req.requestType)
 			}
 		}
 	}()

--- a/confed/restarter.go
+++ b/confed/restarter.go
@@ -6,11 +6,11 @@ import (
 )
 
 const (
-	SERVICE_CMD = "/usr/sbin/service"
+	SERVICE_CMD = "systemctl"
 )
 
 func restartService(name string) (err error) {
-	_, err = runCommand(false, nil, SERVICE_CMD, name, "restart-or-reload")
+	_, err = runCommand(false, nil, SERVICE_CMD, "reload-or-restart", name)
 	return
 }
 

--- a/confed/restarter.go
+++ b/confed/restarter.go
@@ -38,7 +38,7 @@ func RunRequestHandler(ch chan Request) {
 					wbgong.Error.Printf("Error restarting %s: %s", service, err)
 				}
 			default:
-				wbgong.Debug.Printf("Unknown request type %d", req.requestType)
+				wbgong.Error.Printf("Unknown request type %d", req.requestType)
 			}
 		}
 	}()

--- a/confed/schema.go
+++ b/confed/schema.go
@@ -20,6 +20,7 @@ type JSONSchemaProps struct {
 	fromJSONCommand         []string
 	toJSONCommand           []string
 	services                []string
+	restartDelayMS          int
 	shouldValidate          bool
 	hideFromList            bool
 	TitleTranslations       map[string]string `json:"titleTranslations,omitempty"`
@@ -123,6 +124,7 @@ func NewJSONSchemaWithRoot(schemaPath, root string) (s *JSONSchema, err error) {
 	}
 
 	services, _ := extractStringOrStringList(configFile,"service")
+	restartDelayMS, _ := configFile["restartDelayMS"].(float64)
 	editor, _ := configFile["editor"].(string)
 
 	title, _ := parsed["title"].(string)
@@ -168,6 +170,7 @@ func NewJSONSchemaWithRoot(schemaPath, root string) (s *JSONSchema, err error) {
 			fromJSONCommand:         fromJSONCommand,
 			toJSONCommand:           toJSONCommand,
 			services:                services,
+			restartDelayMS:          int(restartDelayMS),
 			shouldValidate:          shouldValidate,
 			hideFromList:            hideFromList,
 			TitleTranslations:       titleTranslations,
@@ -255,6 +258,10 @@ func (s *JSONSchema) Description() string {
 
 func (s *JSONSchema) Services() []string {
 	return s.props.services
+}
+
+func (s *JSONSchema) RestartDelayMS() int {
+	return s.props.restartDelayMS
 }
 
 func (s *JSONSchema) ShouldValidate() bool {

--- a/confed/schema.go
+++ b/confed/schema.go
@@ -19,7 +19,7 @@ type JSONSchemaProps struct {
 	physicalConfigPath      string
 	fromJSONCommand         []string
 	toJSONCommand           []string
-	service                 string
+	service                 []string
 	restartDelayMS          int
 	shouldValidate          bool
 	hideFromList            bool
@@ -42,7 +42,7 @@ func subconfKey(path, pattern, ptrString string) string {
 	return path + "\x00" + pattern + "\x00" + ptrString
 }
 
-func extractCommand(msi map[string]interface{}, key string) ([]string, error) {
+func extractStringList(msi map[string]interface{}, key string) ([]string, error) {
 	cmd, found := msi[key]
 	if !found {
 		return nil, nil
@@ -103,12 +103,12 @@ func NewJSONSchemaWithRoot(schemaPath, root string) (s *JSONSchema, err error) {
 		return
 	}
 
-	fromJSONCommand, err := extractCommand(configFile, "fromJSON")
+	fromJSONCommand, err := extractStringList(configFile, "fromJSON")
 	if err != nil {
 		return
 	}
 
-	toJSONCommand, err := extractCommand(configFile, "toJSON")
+	toJSONCommand, err := extractStringList(configFile, "toJSON")
 	if err != nil {
 		return
 	}
@@ -123,7 +123,7 @@ func NewJSONSchemaWithRoot(schemaPath, root string) (s *JSONSchema, err error) {
 		hideFromList = false
 	}
 
-	service, _ := configFile["service"].(string)
+	service, _ := extractStringList(configFile,"service")
 	restartDelayMS, _ := configFile["restartDelayMS"].(float64)
 	editor, _ := configFile["editor"].(string)
 
@@ -256,7 +256,7 @@ func (s *JSONSchema) Description() string {
 	return s.props.Description
 }
 
-func (s *JSONSchema) Service() string {
+func (s *JSONSchema) Service() []string {
 	return s.props.service
 }
 

--- a/confed/schema.go
+++ b/confed/schema.go
@@ -20,7 +20,6 @@ type JSONSchemaProps struct {
 	fromJSONCommand         []string
 	toJSONCommand           []string
 	services                []string
-	restartDelayMS          int
 	shouldValidate          bool
 	hideFromList            bool
 	TitleTranslations       map[string]string `json:"titleTranslations,omitempty"`
@@ -124,7 +123,6 @@ func NewJSONSchemaWithRoot(schemaPath, root string) (s *JSONSchema, err error) {
 	}
 
 	services, _ := extractStringOrStringList(configFile,"service")
-	restartDelayMS, _ := configFile["restartDelayMS"].(float64)
 	editor, _ := configFile["editor"].(string)
 
 	title, _ := parsed["title"].(string)
@@ -170,7 +168,6 @@ func NewJSONSchemaWithRoot(schemaPath, root string) (s *JSONSchema, err error) {
 			fromJSONCommand:         fromJSONCommand,
 			toJSONCommand:           toJSONCommand,
 			services:                services,
-			restartDelayMS:          int(restartDelayMS),
 			shouldValidate:          shouldValidate,
 			hideFromList:            hideFromList,
 			TitleTranslations:       titleTranslations,
@@ -258,10 +255,6 @@ func (s *JSONSchema) Description() string {
 
 func (s *JSONSchema) Services() []string {
 	return s.props.services
-}
-
-func (s *JSONSchema) RestartDelayMS() int {
-	return s.props.restartDelayMS
 }
 
 func (s *JSONSchema) ShouldValidate() bool {

--- a/confed/schema.go
+++ b/confed/schema.go
@@ -19,7 +19,7 @@ type JSONSchemaProps struct {
 	physicalConfigPath      string
 	fromJSONCommand         []string
 	toJSONCommand           []string
-	service                 []string
+	services                []string
 	restartDelayMS          int
 	shouldValidate          bool
 	hideFromList            bool
@@ -123,7 +123,7 @@ func NewJSONSchemaWithRoot(schemaPath, root string) (s *JSONSchema, err error) {
 		hideFromList = false
 	}
 
-	service, _ := extractStringOrStringList(configFile,"service")
+	services, _ := extractStringOrStringList(configFile,"service")
 	restartDelayMS, _ := configFile["restartDelayMS"].(float64)
 	editor, _ := configFile["editor"].(string)
 
@@ -169,7 +169,7 @@ func NewJSONSchemaWithRoot(schemaPath, root string) (s *JSONSchema, err error) {
 			Description:             description,
 			fromJSONCommand:         fromJSONCommand,
 			toJSONCommand:           toJSONCommand,
-			service:                 service,
+			services:                services,
 			restartDelayMS:          int(restartDelayMS),
 			shouldValidate:          shouldValidate,
 			hideFromList:            hideFromList,
@@ -256,8 +256,8 @@ func (s *JSONSchema) Description() string {
 	return s.props.Description
 }
 
-func (s *JSONSchema) Service() []string {
-	return s.props.service
+func (s *JSONSchema) Services() []string {
+	return s.props.services
 }
 
 func (s *JSONSchema) RestartDelayMS() int {

--- a/confed/schema.go
+++ b/confed/schema.go
@@ -42,7 +42,7 @@ func subconfKey(path, pattern, ptrString string) string {
 	return path + "\x00" + pattern + "\x00" + ptrString
 }
 
-func extractStringList(msi map[string]interface{}, key string) ([]string, error) {
+func extractStringOrStringList(msi map[string]interface{}, key string) ([]string, error) {
 	cmd, found := msi[key]
 	if !found {
 		return nil, nil
@@ -103,12 +103,12 @@ func NewJSONSchemaWithRoot(schemaPath, root string) (s *JSONSchema, err error) {
 		return
 	}
 
-	fromJSONCommand, err := extractStringList(configFile, "fromJSON")
+	fromJSONCommand, err := extractStringOrStringList(configFile, "fromJSON")
 	if err != nil {
 		return
 	}
 
-	toJSONCommand, err := extractStringList(configFile, "toJSON")
+	toJSONCommand, err := extractStringOrStringList(configFile, "toJSON")
 	if err != nil {
 		return
 	}
@@ -123,7 +123,7 @@ func NewJSONSchemaWithRoot(schemaPath, root string) (s *JSONSchema, err error) {
 		hideFromList = false
 	}
 
-	service, _ := extractStringList(configFile,"service")
+	service, _ := extractStringOrStringList(configFile,"service")
 	restartDelayMS, _ := configFile["restartDelayMS"].(float64)
 	editor, _ := configFile["editor"].(string)
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+wb-mqtt-confed (1.13.0) stable; urgency=medium
+
+  * Support several services to restart
+  * Relace services restart to restart-or-reload
+
+ -- Ekaterina Volkova <ekaterina.volkova@wirenboard.ru>  Tue, 25 Apr 2023 13:41:26 +0300
+
 wb-mqtt-confed (1.12.0) stable; urgency=medium
 
   * Support editor property in config schemas

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,7 +1,7 @@
 wb-mqtt-confed (1.13.0) stable; urgency=medium
 
   * Support several services to restart
-  * Relace services restart to restart-or-reload
+  * Relace services restart to reload-or-restart
 
  -- Ekaterina Volkova <ekaterina.volkova@wirenboard.ru>  Tue, 25 Apr 2023 13:41:26 +0300
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -2,6 +2,7 @@ wb-mqtt-confed (1.13.0) stable; urgency=medium
 
   * Support several services to restart
   * Relace services restart to reload-or-restart
+  * Restart services with systemctl instead of service
 
  -- Ekaterina Volkova <ekaterina.volkova@wirenboard.ru>  Tue, 25 Apr 2023 13:41:26 +0300
 

--- a/debian/debhelper-build-stamp
+++ b/debian/debhelper-build-stamp
@@ -1,1 +1,0 @@
-wb-mqtt-confed

--- a/debian/debhelper-build-stamp
+++ b/debian/debhelper-build-stamp
@@ -1,0 +1,1 @@
+wb-mqtt-confed

--- a/main.go
+++ b/main.go
@@ -118,7 +118,7 @@ func main() {
 	if !gotSome {
 		wbgong.Error.Fatalf("no valid schemas found")
 	}
-	confed.RunRestarter(editor.RestartCh)
+	confed.RunRequestHandler(editor.RequestCh)
 
 	if *brokerAddress == DEFAULT_BROKER_URL && isSocket(MOSQUITTO_SOCK_FILE) {
 		wbgong.Info.Println("broker URL is default and mosquitto socket detected, trying to connect via it")


### PR DESCRIPTION
Добавлена возможность составления списка сервисов для перезапуска
Если у сервиса определена команда ExecReload, то будет выполнен reload, иначе restart
В первую очередь, это делается для сервиса dbus публикатора, потому что ему необходимо перепроверять connectivity после того как обновляется файл конфига и перезапускается wb-connection-manager. Вместо попыток свзать эти сервисы через systemd, был определен ExecReload у wb-mqtt-nm-helper