### PR TITLE
Output config preprocessing warnings

### DIFF
--- a/confed/editor.go
+++ b/confed/editor.go
@@ -228,8 +228,8 @@ func (editor *Editor) Load(args *EditorPathArgs, reply *EditorContentResponse) e
 		wbgong.Error.Printf("Failed to read config file %s: %s", schema.PhysicalConfigPath(), err)
 		return invalidConfigError
 	}
-	if len(bs.preprocessErrors) != 0 {
-		wbgong.Warn.Printf("Load config %s: %s", schema.PhysicalConfigPath(), bs.preprocessErrors)
+	if len(bs.preprocessorErrors) != 0 {
+		wbgong.Warn.Printf("config preprocessor of %s printed in stderr: %s", schema.PhysicalConfigPath(), bs.preprocessorErrors)
 	}
 
 	if schema.ShouldValidate() {
@@ -298,7 +298,7 @@ func (editor *Editor) Save(args *EditorSaveArgs, reply *EditorPathResponse) erro
 		}
 		bs = output.stdout.Bytes()
 		if output.stderr.Len() != 0 {
-			wbgong.Warn.Printf("save config %s: %s", schema.PhysicalConfigPath(), output.stderr.String())
+			wbgong.Warn.Printf("config preprocessor of %s printed in stderr: %s", schema.PhysicalConfigPath(), output.stderr.String())
 		}
 	} else {
 		var indented bytes.Buffer

--- a/confed/editor.go
+++ b/confed/editor.go
@@ -9,7 +9,6 @@ import (
 	"sort"
 	"sync"
 	"strconv"
-	"strings"	
 )
 
 const (
@@ -42,8 +41,10 @@ func fixFormatProps(v interface{}) interface{} {
 }
 
 func printPreprocessorErrors(configPath string, errors string) {
-	for _, err := range strings.Split(errors, "\n") {
-		wbgong.Warn.Printf("config preprocessor of %s printed in stderr: %s", configPath, err)
+	if len(errors) > 0 {
+		for _, err := range errors.splitlines() {
+			wbgong.Warn.Printf("config preprocessor of %s printed in stderr: %s", configPath, err)
+		}
 	}
 }
 

--- a/confed/editor.go
+++ b/confed/editor.go
@@ -9,6 +9,7 @@ import (
 	"sort"
 	"sync"
 	"strconv"
+	"strings"
 )
 
 const (
@@ -42,7 +43,7 @@ func fixFormatProps(v interface{}) interface{} {
 
 func printPreprocessorErrors(configPath string, errors string) {
 	if len(errors) > 0 {
-		for _, err := range errors.splitlines() {
+		for _, err := range strings.Split(errors, "\n") {
 			wbgong.Warn.Printf("config preprocessor of %s printed in stderr: %s", configPath, err)
 		}
 	}

--- a/confed/editor.go
+++ b/confed/editor.go
@@ -43,7 +43,7 @@ func fixFormatProps(v interface{}) interface{} {
 
 func printPreprocessorErrors(configPath string, errors string) {
 	if len(errors) > 0 {
-		for _, err := range strings.Split(strings.TrimRight(errors, "\n"), "\n") {
+		for _, err := range strings.Split(strings.TrimSpace(errors), "\n") {
 			wbgong.Warn.Printf("config preprocessor of %s printed in stderr: %s", configPath, err)
 		}
 	}

--- a/confed/editor.go
+++ b/confed/editor.go
@@ -229,7 +229,7 @@ func (editor *Editor) Load(args *EditorPathArgs, reply *EditorContentResponse) e
 		return invalidConfigError
 	}
 	if len(bs.preprocessErrors) != 0 {
-		wbgong.Warn.Printf("Load config warning, %s: %s", schema.PhysicalConfigPath(), bs.preprocessErrors)
+		wbgong.Warn.Printf("Load config %s: %s", schema.PhysicalConfigPath(), bs.preprocessErrors)
 	}
 
 	if schema.ShouldValidate() {
@@ -298,7 +298,7 @@ func (editor *Editor) Save(args *EditorSaveArgs, reply *EditorPathResponse) erro
 		}
 		bs = output.stdout.Bytes()
 		if output.stderr.Len() != 0 {
-			wbgong.Warn.Printf("external command warning, %s: %s", schema.PhysicalConfigPath(), output.stderr.String())
+			wbgong.Warn.Printf("save config %s: %s", schema.PhysicalConfigPath(), output.stderr.String())
 		}
 	} else {
 		var indented bytes.Buffer

--- a/confed/editor.go
+++ b/confed/editor.go
@@ -43,7 +43,7 @@ func fixFormatProps(v interface{}) interface{} {
 
 func printPreprocessorErrors(configPath string, errors string) {
 	if len(errors) > 0 {
-		for _, err := range strings.Split(errors, "\n") {
+		for _, err := range strings.Split(strings.TrimRight(errors, "\n"), "\n") {
 			wbgong.Warn.Printf("config preprocessor of %s printed in stderr: %s", configPath, err)
 		}
 	}

--- a/confed/enumloader.go
+++ b/confed/enumloader.go
@@ -48,7 +48,8 @@ func (c *subconfWatcherClient) LiveRemoveFile(path string) error {
 
 func (e *enumLoader) loadSubconf(key, path string, ptr gojsonpointer.JsonPointer) (err error) {
 	wbgong.Debug.Printf("enumLoader.loadSubconf(): %s, %s", key, path)
-	content, err := loadConfigBytes(path, nil)
+	bs, err := loadConfigBytes(path, nil)
+	content := bs.content 
 	if err != nil {
 		wbgong.Debug.Printf("enumLoader.loadSubconf(): %s load failed: %s", path, err)
 		return

--- a/confed/enumloader_test.go
+++ b/confed/enumloader_test.go
@@ -83,7 +83,7 @@ func (s *EnumLoaderSuite) verifyEnum(enumSubst string) {
 	bs, err := loadConfigBytes(s.DataFilePath("sample.schema.json"), nil)
 	s.Ck("loadConfigBytes()", err)
 	var m map[string]interface{}
-	s.Ck("Unmarshal JSON", json.Unmarshal(bs, &m))
+	s.Ck("Unmarshal JSON", json.Unmarshal(bs.content, &m))
 	// TBD: specify the base directory for Preprocess
 	s.Equal(s.expectedContent(enumSubst), s.enumLoader.Preprocess(m))
 	s.False(s.enumLoader.IsDirty())

--- a/confed/extpp_test.go
+++ b/confed/extpp_test.go
@@ -12,7 +12,7 @@ func TestExtPreprocess(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
-	if string(out.Bytes()) != "abc:def:ghi" {
+	if string(out.stdout.Bytes()) != "abc:def:ghi" {
 		t.Fatalf("unexpected output: %s", out)
 	}
 }

--- a/confed/schema.go
+++ b/confed/schema.go
@@ -79,7 +79,8 @@ func addTranslation(strings map[string]interface{}, lang string, key string, dst
 }
 
 func NewJSONSchemaWithRoot(schemaPath, root string) (s *JSONSchema, err error) {
-	content, err := loadConfigBytes(schemaPath, nil)
+	bs, err := loadConfigBytes(schemaPath, nil)
+	content := bs.content
 	if err != nil {
 		return
 	}
@@ -221,7 +222,7 @@ func (s *JSONSchema) ValidateFile(path string) (result *gojsonschema.Result, err
 	if err != nil {
 		return
 	}
-	return s.ValidateContent(bs)
+	return s.ValidateContent(bs.content)
 }
 
 func (s *JSONSchema) Path() string {

--- a/confed/util.go
+++ b/confed/util.go
@@ -53,7 +53,7 @@ func extPreprocess(commandAndArgs []string, in []byte) (RunCommandResult, error)
 
 type LoadConfigResult struct {
 	content []byte
-	preprocessErrors string
+	preprocessorErrors string
 }
 
 func loadConfigBytes(path string, preprocessCmd []string) (res LoadConfigResult, err error) {
@@ -77,7 +77,7 @@ func loadConfigBytes(path string, preprocessCmd []string) (res LoadConfigResult,
 		}
 		jsonInput = &output.stdout
 		if output.stderr.Len() != 0 {
-			res.preprocessErrors = output.stderr.String()
+			res.preprocessorErrors = output.stderr.String()
 		}
 	}
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-confed (1.13.1) stable; urgency=medium
+
+  * Output config preprocessing warnings
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.com>  Tue, 29 Aug 2023 11:49:03 +0500
+
 wb-mqtt-confed (1.13.0) stable; urgency=medium
 
   * Support several services to restart


### PR DESCRIPTION
При записи и чтении конфига с преобразованием wb-mqtt-confed смотрит на результат вызова команды преобразования. Если команда завершилась без ошибки, то вывод в stderr проглатывается. В нём могут быть важные для диагностики предупреждения. Теперь вывод команд пишется в лог