### PR TITLE
Fix service crash on schema change

### DIFF
--- a/confed/patchloader.go
+++ b/confed/patchloader.go
@@ -121,5 +121,7 @@ func (pl *patchLoader) IsDirty() (dirty bool) {
 func (pl *patchLoader) StopWatchingPatches() {
 	pl.Lock()
 	defer pl.Unlock()
-	pl.watcher.Stop()
+	if pl.watcher != nil {
+		pl.watcher.Stop()
+	}
 }

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-confed (1.14.1) stable; urgency=medium
+
+  * Fix service crash on schema change
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.com>  Thu, 18 Jan 2024 10:49:45 +0500
+
 wb-mqtt-confed (1.14.0) stable; urgency=medium
 
   * Support for RFC7396 JSON merge patches for config schemas.


### PR DESCRIPTION
Если к схеме не обращались и она изменилась в фоне, watcher не создавался, но вызывалась функция остановки. В результате было обращение к nil