### PR TITLE
Fix config saving errors reporting

### DIFF
--- a/confed/extpp_test.go
+++ b/confed/extpp_test.go
@@ -17,7 +17,7 @@ func TestExtPreprocess(t *testing.T) {
 	}
 }
 
-func SkipTestExtError(t *testing.T) {
+func TestExtError(t *testing.T) {
 	_, err := extPreprocess([]string{
 		"--no-such-command--please-don't-create-it--",
 	}, []byte("abc-def-ghi"))
@@ -26,7 +26,7 @@ func SkipTestExtError(t *testing.T) {
 	}
 }
 
-func SkipTestExtCaptureStderr(t *testing.T) {
+func TestExtCaptureStderr(t *testing.T) {
 	_, err := extPreprocess([]string{
 		"sh", "-c", "echo 'zzz qqq' 1>&2; exit 42",
 	}, []byte("foobar"))

--- a/confed/util.go
+++ b/confed/util.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"github.com/DisposaBoy/JsonConfigReader"
 	"io"
 	"io/ioutil"
 	"os"
@@ -12,6 +11,8 @@ import (
 	"path/filepath"
 	"strings"
 	"syscall"
+
+	"github.com/DisposaBoy/JsonConfigReader"
 )
 
 type RunCommandResult struct {
@@ -26,7 +27,8 @@ func runCommand(captureStdout bool, stdin io.Reader, command string, args ...str
 		cmd.Stdout = &res.stdout
 	}
 	cmd.Stderr = &res.stderr
-	if err := cmd.Run(); err != nil {
+	err = cmd.Run()
+	if err != nil {
 		exitErr, ok := err.(*exec.ExitError)
 		if ok {
 			status := -1 // FIXME
@@ -52,7 +54,7 @@ func extPreprocess(commandAndArgs []string, in []byte) (RunCommandResult, error)
 }
 
 type LoadConfigResult struct {
-	content []byte
+	content            []byte
 	preprocessorErrors string
 }
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-confed (1.14.3) stable; urgency=medium
+
+  * Fix config saving errors reporting 
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.com>  Thu, 18 Jan 2024 12:49:05 +0500
+
 wb-mqtt-confed (1.14.2) stable; urgency=medium
 
   * Add arm64 build, no functional changes


### PR DESCRIPTION
Создавалась локальная переменная err, которая перекрывала объявленный в заголовке функции err. В результате ошибки из функции никогда не возвращались