### PR TITLE
Fix false positive error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ amd64:
 
 test:
 	cp amd64.wbgo.so confed/wbgo.so
-	CC=x86_64-linux-gnu-gcc go test -v -trimpath -ldflags="-s -w" ./confed
+	CC=x86_64-linux-gnu-gcc go test -v -trimpath -ldflags="-s -w" -tags test ./confed
 
 wb-mqtt-confed: main.go confed/*.go
 	$(GO_ENV) $(GO) build -trimpath $(GO_FLAGS)

--- a/confed/conffixture.go
+++ b/confed/conffixture.go
@@ -1,3 +1,5 @@
+// +build test
+
 package confed
 
 import (

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-confed (1.14.5) stable; urgency=medium
+
+  * Fix false positive error: 'plugin.Open("./wbgo.so"): realpath failed'
+
+ -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Wed, 07 Feb 2024 14:33:00 +0400
+
 wb-mqtt-confed (1.14.4) stable; urgency=medium
 
   * Stop rpc server on quit


### PR DESCRIPTION
## Before
```sh
wb-mqtt-confed -h
2024/02/07 10:38:12 Error: 'plugin.Open("./wbgo.so"): realpath failed'
Usage of wb-mqtt-confed:
  -broker string
    	MQTT broker url (default "tcp://localhost:1883")
  -debug
    	Enable debugging
  -dump
    	Dump preprocessed schema and exit
  -root string
    	Config root path (default "/")
  -syslog
    	Use syslog for logging
  -testify.m string
    	regular expression to select tests of the testify suite to run
  -validate
    	Validate specified config file and exit
  -wbgo string
    	Location to wbgo.so file (default "/usr/lib/wb-mqtt-confed/wbgo.so")
```

## After
```sh
wb-mqtt-confed -h
Usage of ./wb-mqtt-confed:
  -broker string
    	MQTT broker url (default "tcp://localhost:1883")
  -debug
    	Enable debugging
  -dump
    	Dump preprocessed schema and exit
  -root string
    	Config root path (default "/")
  -syslog
    	Use syslog for logging
  -validate
    	Validate specified config file and exit
  -wbgo string
    	Location to wbgo.so file (default "/usr/lib/wb-mqtt-confed/wbgo.so")
```

## Root cause

`conffixxture.go` imports `github.com/wirenboard/wbgong/testutils`, but it has `init()` function that calls `wbgong.Init("./wbgo.so")`