### PR TITLE
Add profiling support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,7 @@ vendor
 debian/files
 debian/wb-mqtt-confed*
 debian/debhelper-build-stamp
+
+### direnv ###
+.direnv
+.envrc

--- a/confed/sample-comments.json
+++ b/confed/sample-comments.json
@@ -1,5 +1,7 @@
 {
   // sample device definition
+  /* multiline
+     comment */
   "device_type" : "MSU21",
   "name": "MSU21",
   "id": "msu21",

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+wb-mqtt-confed (1.14.6) stable; urgency=medium
+
+  * Add -profile flag to enable profiling with pprof
+  * Support multiline comments in JSON configs
+
+ -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Wed, 21 Feb 2024 14:04:00 +0400
+
 wb-mqtt-confed (1.14.5) stable; urgency=medium
 
   * Fix false positive error: 'plugin.Open("./wbgo.so"): realpath failed'

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/wirenboard/wb-mqtt-confed
 go 1.15
 
 require (
-	github.com/DisposaBoy/JsonConfigReader v0.0.0-20130112093355-33a99fdf1d5e
+	github.com/DisposaBoy/JsonConfigReader v0.0.0-20201129172854-99cf318d67e7
 	github.com/evanphx/json-patch/v5 v5.7.0
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/stretchr/objx v0.3.0

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/DisposaBoy/JsonConfigReader v0.0.0-20130112093355-33a99fdf1d5e h1:rv5qJCfIzQhhefHp8MO98hoGRI3mdps2iiGA3o4nm8A=
-github.com/DisposaBoy/JsonConfigReader v0.0.0-20130112093355-33a99fdf1d5e/go.mod h1:GCzqZQHydohgVLSIqRKZeTt8IGb1Y4NaFfim3H40uUI=
+github.com/DisposaBoy/JsonConfigReader v0.0.0-20201129172854-99cf318d67e7 h1:AJKJCKcb/psppPl/9CUiQQnTG+Bce0/cIweD5w5Q7aQ=
+github.com/DisposaBoy/JsonConfigReader v0.0.0-20201129172854-99cf318d67e7/go.mod h1:GCzqZQHydohgVLSIqRKZeTt8IGb1Y4NaFfim3H40uUI=
 github.com/alexcesaro/statsd v2.0.0+incompatible h1:HG17k1Qk8V1F4UOoq6tx+IUoAbOcI5PHzzEUGeDD72w=
 github.com/alexcesaro/statsd v2.0.0+incompatible/go.mod h1:vNepIbQAiyLe1j480173M6NYYaAsGwEcvuDTU3OCUGY=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/main.go
+++ b/main.go
@@ -5,6 +5,8 @@ import (
 	"flag"
 	"fmt"
 	"log"
+	"net/http"
+	_ "net/http/pprof"
 	"os"
 	"os/signal"
 	"path/filepath"
@@ -43,7 +45,15 @@ func main() {
 	validate := flag.Bool("validate", false, "Validate specified config file and exit")
 	dump := flag.Bool("dump", false, "Dump preprocessed schema and exit")
 	wbgoso := flag.String("wbgo", "/usr/lib/wb-mqtt-confed/wbgo.so", "Location to wbgo.so file")
+	profile := flag.String("profile", "", "Run pprof server")
 	flag.Parse()
+
+	if *profile != "" {
+		go func() {
+			log.Println(http.ListenAndServe(*profile, nil))
+		}()
+	}
+
 	errInit := wbgong.Init(*wbgoso)
 	if errInit != nil {
 		log.Fatalf("ERROR: wbgo.so init failed: '%s'", errInit)


### PR DESCRIPTION
  * Add -profile flag to enable profiling with pprof
 ```sh
# Usage
$ wb-rules -profile 0.0.0.0:6060 ...
$ go tool pprof -http localhost:3435 http://192.168.0.xx:6060/debug/pprof/heap
```
  * readConfig: support multiline comments ([diff](https://github.com/DisposaBoy/JsonConfigReader/compare/33a99fdf1d5e..99cf318d67e7)) (jsoncpp supports multiline comments as well)