### PR TITLE
service: use /etc/default/wb-mqtt-confed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,8 @@ debian/files
 debian/wb-mqtt-confed*
 debian/debhelper-build-stamp
 
+.devcontainer
+
 ### direnv ###
 .direnv
 .envrc

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ GO_ENV := GOARCH=386 CC=i586-linux-gnu-gcc
 endif
 
 GO ?= go
-GO_FLAGS = -ldflags "-w -X main.version=`git describe --tags --always --dirty`"
+GO_FLAGS = -ldflags "-s -w -X main.version=`git describe --tags --always --dirty`"
 
 all: clean wb-mqtt-confed
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-confed (1.14.9) stable; urgency=medium
+
+  * service: use /etc/default/wb-mqtt-confed
+
+ -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Thu, 18 Jul 2024 10:20:00 +0400
+
 wb-mqtt-confed (1.14.8) stable; urgency=medium
 
   * Backup /etc/ntp.conf by moving to /mnt/data

--- a/debian/wb-mqtt-confed.service
+++ b/debian/wb-mqtt-confed.service
@@ -7,7 +7,8 @@ Type=simple
 Restart=on-failure
 RestartSec=1
 User=root
-ExecStart=/usr/bin/wb-mqtt-confed -syslog /usr/share/wb-mqtt-confed/schemas /var/lib/wb-mqtt-confed/schemas
+EnvironmentFile=-/etc/default/wb-mqtt-confed
+ExecStart=/usr/bin/wb-mqtt-confed $WB_MQTT_CONFED_OPTIONS -syslog /usr/share/wb-mqtt-confed/schemas /var/lib/wb-mqtt-confed/schemas
 
 [Install]
 WantedBy=multi-user.target

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/evanphx/json-patch/v5 v5.7.0
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/stretchr/objx v0.3.0
-	github.com/wirenboard/wbgong v0.5.2
+	github.com/wirenboard/wbgong v0.5.3
 	github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f
 	github.com/xeipuuv/gojsonschema v1.2.0
 )

--- a/go.sum
+++ b/go.sum
@@ -19,8 +19,8 @@ github.com/stretchr/objx v0.3.0/go.mod h1:qt09Ya8vawLte6SNmTgCsAVtYtaKzEcn8ATUoH
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-github.com/wirenboard/wbgong v0.5.2 h1:BtnOIhEF8Jiw5fJSZfbP+iLGWYVzeeb5on2/c3buKac=
-github.com/wirenboard/wbgong v0.5.2/go.mod h1:XJWdTJOE6V6SxjgRXymItB+qTy1f0b3PbF9fC78JcTM=
+github.com/wirenboard/wbgong v0.5.3 h1:Ou2gwtlK3B4D2mBBExDMU30PPs4+2m8CrDBEBBjcecE=
+github.com/wirenboard/wbgong v0.5.3/go.mod h1:XJWdTJOE6V6SxjgRXymItB+qTy1f0b3PbF9fC78JcTM=
 github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f h1:J9EGpcZtP0E/raorCMxlFGSTBrsSlaDGf3jU/qvAE2c=
 github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f/go.mod h1:N2zxlSyiKSe5eX1tZViRH5QA0qijqEDrYZiPEAiq3wU=
 github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 h1:EzJWgHovont7NscjpAxXsDA8S8BMYve8Y5+7cuRE7R0=


### PR DESCRIPTION
 * Обновил wbgo (иначе тесты на мастере сломаны) 
 * Сейчас чтобы включить дебаг надо править `/lib/systemd/system/wb-mqtt-confed.service`, потом `systemctl daemon-reload`, но при апдейте пакета оно снова затирается. А так достаточно будет создать `/etc/default/wb-mqtt-confed` c `WB_MQTT_CONFED_OPTIONS=-debug`. Как и в [wb-rules](https://github.com/wirenboard/wb-rules/blob/2691d66582516a9369a5d87fefcbe8035155ccd6/debian/wb-rules.service#L12).