### PR TITLE
Fix log priority

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,3 +1,4 @@
 buildDebGolangWbgo defaultTargets: 'bullseye-armhf bullseye-arm64',
+                   defaultWbGoSoBranch: 'feature/SOFT-4496',
                    defaultRunLintian: true,
                    defaultRunPythonChecks: true

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,3 @@
 buildDebGolangWbgo defaultTargets: 'bullseye-armhf bullseye-arm64',
-                   defaultWbGoSoBranch: 'feature/SOFT-4496',
                    defaultRunLintian: true,
                    defaultRunPythonChecks: true

--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ amd64:
 
 test:
 	cp amd64.wbgo.so confed/wbgo.so
-	CC=x86_64-linux-gnu-gcc go test -v -trimpath -ldflags="-s -w" -tags test ./confed
+	CC=x86_64-linux-gnu-gcc go test -v -trimpath -ldflags="-s -w" -tags test -cover ./confed
 
 wb-mqtt-confed: main.go confed/*.go
 	$(GO_ENV) $(GO) build -trimpath $(GO_FLAGS)

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-confed (1.15.0) stable; urgency=medium
+
+  * update wbgo.so library, fix log priority
+
+ -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Mon, 14 Oct 2024 18:45:00 +0400
+
 wb-mqtt-confed (1.14.12) stable; urgency=medium
 
   * update wbgo.so library, republish retained messages on reconnect to mqtt broker

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/evanphx/json-patch/v5 v5.7.0
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/stretchr/objx v0.3.0
-	github.com/wirenboard/wbgong v0.5.4-0.20241014145417-7c067ad4b18f
+	github.com/wirenboard/wbgong v0.5.4
 	github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f
 	github.com/xeipuuv/gojsonschema v1.2.0
 )

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/evanphx/json-patch/v5 v5.7.0
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/stretchr/objx v0.3.0
-	github.com/wirenboard/wbgong v0.5.3
+	github.com/wirenboard/wbgong v0.5.4-0.20241014145417-7c067ad4b18f
 	github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f
 	github.com/xeipuuv/gojsonschema v1.2.0
 )

--- a/go.sum
+++ b/go.sum
@@ -19,8 +19,8 @@ github.com/stretchr/objx v0.3.0/go.mod h1:qt09Ya8vawLte6SNmTgCsAVtYtaKzEcn8ATUoH
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-github.com/wirenboard/wbgong v0.5.3 h1:Ou2gwtlK3B4D2mBBExDMU30PPs4+2m8CrDBEBBjcecE=
-github.com/wirenboard/wbgong v0.5.3/go.mod h1:XJWdTJOE6V6SxjgRXymItB+qTy1f0b3PbF9fC78JcTM=
+github.com/wirenboard/wbgong v0.5.4-0.20241014145417-7c067ad4b18f h1:EBsNGSUynUtnQyzsmM8oMQHuP8aDq3/77WmI7dl0d0c=
+github.com/wirenboard/wbgong v0.5.4-0.20241014145417-7c067ad4b18f/go.mod h1:XJWdTJOE6V6SxjgRXymItB+qTy1f0b3PbF9fC78JcTM=
 github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f h1:J9EGpcZtP0E/raorCMxlFGSTBrsSlaDGf3jU/qvAE2c=
 github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f/go.mod h1:N2zxlSyiKSe5eX1tZViRH5QA0qijqEDrYZiPEAiq3wU=
 github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 h1:EzJWgHovont7NscjpAxXsDA8S8BMYve8Y5+7cuRE7R0=

--- a/go.sum
+++ b/go.sum
@@ -19,8 +19,8 @@ github.com/stretchr/objx v0.3.0/go.mod h1:qt09Ya8vawLte6SNmTgCsAVtYtaKzEcn8ATUoH
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-github.com/wirenboard/wbgong v0.5.4-0.20241014145417-7c067ad4b18f h1:EBsNGSUynUtnQyzsmM8oMQHuP8aDq3/77WmI7dl0d0c=
-github.com/wirenboard/wbgong v0.5.4-0.20241014145417-7c067ad4b18f/go.mod h1:XJWdTJOE6V6SxjgRXymItB+qTy1f0b3PbF9fC78JcTM=
+github.com/wirenboard/wbgong v0.5.4 h1:XmMTvdbT4pduwOoyR/KoWzR4NQCkVdTb84xZoBvlpPg=
+github.com/wirenboard/wbgong v0.5.4/go.mod h1:XJWdTJOE6V6SxjgRXymItB+qTy1f0b3PbF9fC78JcTM=
 github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f h1:J9EGpcZtP0E/raorCMxlFGSTBrsSlaDGf3jU/qvAE2c=
 github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f/go.mod h1:N2zxlSyiKSe5eX1tZViRH5QA0qijqEDrYZiPEAiq3wU=
 github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 h1:EzJWgHovont7NscjpAxXsDA8S8BMYve8Y5+7cuRE7R0=

--- a/main.go
+++ b/main.go
@@ -33,7 +33,7 @@ func isSocket(path string) bool {
 var version = "unknown"
 
 func main() {
-	if os.Args[1] == "version" {
+	if len(os.Args) > 1 && os.Args[1] == "version" {
 		fmt.Println(version)
 		os.Exit(0)
 	}


### PR DESCRIPTION
* https://github.com/wirenboard/wbgong/pull/17

Test instruction:
```sh
$ mqtt-rpc-client -d wb_logs -s logs -m Load -a '{"levels":{"0":3},"service":"wb-mqtt-confed.service","limit":1}' | jq -r '.[]|.level,.msg'
3
ERROR: Error loading schema: no configFile section in the schema
```
* enable coverage summary:
```
coverage: 44.3% of statements
```
* [minor] fix crash with no args

Before:
```sh
$ wb-mqtt-confed
panic: runtime error: index out of range [1] with length 1

goroutine 1 [running]:
main.main()
	github.com/wirenboard/wb-mqtt-confed/main.go:36 +0x1030
```

After:
```sh
$ wb-mqtt-confed
ERROR: 2024/10/14 16:02:57 must specify schema(s) / schema directory(ies)
```