### PR TITLE
Fix postinst script

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-confed (1.17.2) stable; urgency=medium
+
+  * Fix postinst script
+
+ -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Fri, 05 Jun 2026 17:00:00 +0400
+
 wb-mqtt-confed (1.17.1) stable; urgency=medium
 
   * Bump github.com/wirenboard/wbgong to 0.7.3

--- a/debian/wb-mqtt-confed.postinst
+++ b/debian/wb-mqtt-confed.postinst
@@ -6,7 +6,7 @@ set -e
 old_ntp_conf="/etc/ntp.conf"
 if [ -f $old_ntp_conf ]; then
     ntp_conf_calculated_hash=$(md5sum "$old_ntp_conf" | cut -f 1 -d ' ')
-    if [ "$wb_conf_calculated_hash" == "4c8b0024bac256f7f7f5b2732b79b33a" ]; then
+    if [ "$ntp_conf_calculated_hash" == "4c8b0024bac256f7f7f5b2732b79b33a" ]; then
         echo "Removing old $old_ntp_conf"
         rm -f $old_ntp_conf || true
     else

--- a/debian/wb-mqtt-confed.postinst
+++ b/debian/wb-mqtt-confed.postinst
@@ -5,7 +5,7 @@ set -e
 # ntp config is now in /etc/ntpsec/
 old_ntp_conf="/etc/ntp.conf"
 if [ -f $old_ntp_conf ]; then
-    local ntp_conf_calculated_hash=$(md5sum "$old_ntp_conf" | cut -f 1 -d ' ')
+    ntp_conf_calculated_hash=$(md5sum "$old_ntp_conf" | cut -f 1 -d ' ')
     if [ "$wb_conf_calculated_hash" == "4c8b0024bac256f7f7f5b2732b79b33a" ]; then
         echo "Removing old $old_ntp_conf"
         rm -f $old_ntp_conf || true


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**
```sh
19:44:21 /var/lib/dpkg/info/wb-mqtt-confed.postinst: 8: local: not in a function
19:44:21 dpkg: error processing package wb-mqtt-confed (--configure):
19:44:21  installed wb-mqtt-confed package post-installation script subprocess returned error exit status 2
```

___________________________________
**Что поменялось для пользователей:**
ничего

___________________________________
**Как проверял/а:**


