### PR TITLE
Add ntpsec to dependencies

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-confed (1.17.3) stable; urgency=medium
+
+  * Add ntpsec to dependencies
+
+ -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Mon, 08 Jun 2026 12:00:00 +0400
+
 wb-mqtt-confed (1.17.2) stable; urgency=medium
 
   * Fix postinst script

--- a/debian/control
+++ b/debian/control
@@ -3,12 +3,18 @@ Maintainer: Wiren Board team <info@wirenboard.com>
 Section: misc
 Priority: optional
 Standards-Version: 3.9.2
-Build-Depends: debhelper-compat (= 13), golang-1.24-go:native
+Build-Depends: debhelper-compat (= 13),
+               golang-1.24-go:native
 Homepage: https://github.com/wirenboard/wb-mqtt-confed
 
 Package: wb-mqtt-confed
 Architecture: any
-Depends: libc6 (>= 2.13), python3 (>= 3.5), python3-pyparsing, python3-netaddr, ${misc:Depends}
+Depends: libc6 (>= 2.13),
+         ntpsec,
+         python3 (>= 3.5),
+         python3-pyparsing,
+         python3-netaddr,
+         ${misc:Depends}
 Breaks: wb-homa-modbus (<< 1.14.1), wb-mqtt-serial (<< 1.14.3), wb-homa-adc (<< 1.10.6), wb-homa-gpio (<< 1.13.7), wb-mqtt-db (<< 1.3.3), wb-mqtt-lirc (<< 1.1.2), wb-rules (<< 1.6.3), wb-hwconf-manager (<< 1.3.6)
 Description: Wiren Board Configuration Editor Backend
  wb-mqtt-confed is a service which provides MQTT-RPC methods


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**
Сейчас wb-mqtt-confed обновляется до установки ntpsec (так как его нет в явных зависимостях), в результате:
```sh
Moving existing ntp.conf to /etc/ntpsec/
mv: cannot move '/etc/ntp.conf' to '/etc/ntpsec/': Not a directory
```

___________________________________
**Что поменялось для пользователей:**
ничего

___________________________________
**Как проверял/а:**


