### PR TITLE
Fix ntp config migration

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-confed (1.17.4) stable; urgency=medium
+
+  * Fix ntp config migration
+
+ -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Thu, 11 Jun 2026 15:00:00 +0400
+
 wb-mqtt-confed (1.17.3) stable; urgency=medium
 
   * Add ntpsec to dependencies

--- a/debian/wb-mqtt-confed.postinst
+++ b/debian/wb-mqtt-confed.postinst
@@ -4,6 +4,7 @@ set -e
 
 # ntp config is now in /etc/ntpsec/
 old_ntp_conf="/etc/ntp.conf"
+new_ntp_conf="/etc/ntpsec/ntp.conf"
 if [ -f $old_ntp_conf ]; then
     ntp_conf_calculated_hash=$(md5sum "$old_ntp_conf" | cut -f 1 -d ' ')
     if [ "$ntp_conf_calculated_hash" == "4c8b0024bac256f7f7f5b2732b79b33a" ]; then
@@ -11,7 +12,7 @@ if [ -f $old_ntp_conf ]; then
         rm -f $old_ntp_conf || true
     else
         echo "Moving existing ntp.conf to /etc/ntpsec/"
-        mv $old_ntp_conf /etc/ntpsec/
+        sed 's#/var/lib/ntp#/var/lib/ntpsec#' $old_ntp_conf > $new_ntp_conf
     fi
 fi
 


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**
после обновления с ntp на ntpsec:
```
LOG: frequency file /var/lib/ntp/ntp.drift-tmp: Permission denied
```

___________________________________
**Что поменялось для пользователей:**


___________________________________
**Как проверял/а:**


