### PR TITLE
Fix postinst script

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-confed (1.17.6) stable; urgency=medium
+
+  * Fix postinst script
+
+ -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Tue, 21 Jul 2026 14:20:00 +0400
+
 wb-mqtt-confed (1.17.5) stable; urgency=medium
 
   * Update wbgo.so

--- a/debian/wb-mqtt-confed.postinst
+++ b/debian/wb-mqtt-confed.postinst
@@ -7,7 +7,7 @@ old_ntp_conf="/etc/ntp.conf"
 new_ntp_conf="/etc/ntpsec/ntp.conf"
 if [ -f $old_ntp_conf ]; then
     ntp_conf_calculated_hash=$(md5sum "$old_ntp_conf" | cut -f 1 -d ' ')
-    if [ "$ntp_conf_calculated_hash" == "4c8b0024bac256f7f7f5b2732b79b33a" ]; then
+    if [ "$ntp_conf_calculated_hash" = "4c8b0024bac256f7f7f5b2732b79b33a" ]; then
         echo "Removing old $old_ntp_conf"
         rm -f $old_ntp_conf || true
     else


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**
в процессе апгрейда:
```sh
10:17:09 /var/lib/dpkg/info/wb-mqtt-confed.postinst: 10: [: 4c8b0024bac256f7f7f5b2732b79b33a: unexpected operator
```
так как выполняется в dash, не в bash

___________________________________
**Что поменялось для пользователей:**
ничего

___________________________________
**Как проверял/а:**


