### PR TITLE
Bump go to 1.26

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,3 +1,4 @@
 buildDebGolangWbgo defaultTargets: 'current-armhf current-arm64',
+                   defaultGoVersion: '1.26',
                    defaultRunLintian: true,
                    defaultRunPythonChecks: true

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-confed (1.18.1) stable; urgency=medium
+
+  * Use go 1.26 compiler
+
+ -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Thu, 06 Aug 2026 17:50:00 +0400
+
 wb-mqtt-confed (1.18.0) stable; urgency=medium
 
   * Update dependencies

--- a/debian/control
+++ b/debian/control
@@ -2,9 +2,9 @@ Source: wb-mqtt-confed
 Maintainer: Wiren Board team <info@wirenboard.com>
 Section: misc
 Priority: optional
-Standards-Version: 3.9.2
+Standards-Version: 4.5.1
 Build-Depends: debhelper-compat (= 13),
-               golang-1.24-go:native
+               golang-1.26-go:native
 Homepage: https://github.com/wirenboard/wb-mqtt-confed
 
 Package: wb-mqtt-confed

--- a/debian/rules
+++ b/debian/rules
@@ -1,6 +1,6 @@
 #!/usr/bin/make -f
 
-export PATH := /usr/lib/go-1.24/bin:$(PATH)
+export PATH := /usr/lib/go-1.26/bin:$(PATH)
 
 %:
 	dh $@ --parallel


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**
Из релизнотов https://go.dev/doc/go1.26#faster-cgo-calls

> Faster cgo calls
> 
> The baseline runtime overhead of cgo calls has been reduced by ~30%.

у нас через cgo идет работа с wbgo

___________________________________
**Что поменялось для пользователей:**
ничего

___________________________________
**Как проверял/а:**
на вб

